### PR TITLE
feat: add Vault Mock

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -20,6 +20,12 @@ type VaultConfig struct {
 	Cert      string
 }
 
+type IVaultService interface {
+	NewVaultService(cfg *VaultConfig) IVaultService
+	GetSecret(key VaultSecretKey, clientSlug string) (string, error)
+	GetSecrets(clientSlug string, keys []string) (map[string]interface{}, error)
+}
+
 type VaultService struct {
 	config *VaultConfig
 	client *api.Client
@@ -29,8 +35,8 @@ type VaultSecretKey string
 
 var Vault = VaultService{}
 
-func (v *VaultService) NewVaultService(cfg *VaultConfig) VaultService {
-	service := VaultService{
+func (v *VaultService) NewVaultService(cfg *VaultConfig) IVaultService {
+	service := &VaultService{
 		config: cfg,
 	}
 	service.init()

--- a/vault_mock.go
+++ b/vault_mock.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"fmt"
+)
+
+type VaultMockService struct {
+	config   *VaultConfig
+	mockData *map[string]string
+}
+
+var VaultMock = VaultMockService{
+	mockData: &map[string]string{
+		"DATABASE_HOST": "localhost",
+		"DATABASE_NAME": "dial_somosdialog_dev",
+		"DATABASE_USER": "root",
+		"DATABASE_PASS": "",
+	},
+}
+
+func (v *VaultMockService) NewVaultService(cfg *VaultConfig) IVaultService {
+	service := &VaultMockService{
+		config: cfg,
+	}
+	return service
+}
+
+func (s *VaultMockService) GetSecret(key VaultSecretKey, clientSlug string) (string, error) {
+
+	value, ok := (*s.mockData)[string(key)]
+	if !ok {
+		return "", fmt.Errorf("secret value type assertion failed")
+	}
+
+	return value, nil
+}
+
+func (s *VaultMockService) GetSecrets(clientSlug string, keys []string) (map[string]interface{}, error) {
+	filteredSecrets := make(map[string]interface{})
+	for _, key := range keys {
+		if s.mockData == nil {
+			if val, ok := (*s.mockData)[key]; ok {
+				filteredSecrets[key] = val
+			}
+		}
+	}
+
+	return filteredSecrets, nil
+}
+
+func SetVaultMockData(data *map[string]string) IVaultService {
+	VaultMock = VaultMockService{
+		mockData: data,
+	}
+
+	return &VaultMock
+}


### PR DESCRIPTION
Para tornar a nossa vida mais fácil, resolvi criar as funções para retornar um Mock através do Vault.
Agora em ambiente de desenvolvimento, se quiser utilziar o Vault com Mock, basta alterar a função que cria os mocks.

Sem usar o Mock

```
vault := utils.Vault.NewVaultService(&utils.VaultConfig{
	RoleId:    config.Vault.RoleId,
	SecretId:  config.Vault.SecretId,
	Url:       config.Vault.Url,
	MountPath: config.Vault.MountPath,
	Cert:      config.Vault.Cert,
})
```


Usando o Mock

```
vault := utils.VaultMock.NewVaultService(&utils.VaultConfig{
	RoleId:    config.Vault.RoleId,
	SecretId:  config.Vault.SecretId,
	Url:       config.Vault.Url,
	MountPath: config.Vault.MountPath,
	Cert:      config.Vault.Cert,
})
```


Para atualizar os dados do Mock, basta usar a seguinte função, exemplo:

```
s.vault = utils.SetVaultMockData(&map[string]string{
	"DATABASE_HOST": "localhost",
	"DATABASE_NAME": "dial_newsomosdialog_dev",
	"DATABASE_PASS": "123456",
	"DATABASE_USER": "root",
})
```

**Lembrando que é necessário ainda alterar no projeto que for utilizar o mock, não utilizar o VaultService e sim o IVaultService**


