### PR TITLE
fix: add error to NewVaultService return

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -34,12 +34,12 @@ type VaultSecretKey string
 
 var Vault = VaultService{}
 
-func NewVaultService(cfg *VaultConfig) IVaultService {
+func NewVaultService(cfg *VaultConfig) (IVaultService, error) {
 	service := &VaultService{
 		config: cfg,
 	}
-	service.init()
-	return service
+	err := service.init()
+	return service, err
 }
 
 func (s *VaultService) init() error {


### PR DESCRIPTION
Add error do NewVaultService return to better error tracking of vault initiation